### PR TITLE
Fix unsafe Vector deref and remove unnecessary nightly features

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,3 @@
-#![feature(iter_collect_into)]
 
 use crate::common::search_libs;
 use bindgen::callbacks::{MacroParsingBehavior, ParseCallbacks};

--- a/build/common.rs
+++ b/build/common.rs
@@ -110,36 +110,32 @@ pub fn search_files(filenames: &[String], variable: &str) -> Vec<(PathBuf, Strin
 
     // Search the directories in the `LD_LIBRARY_PATH` environment variable.
     if let Ok(path) = env::var("LD_LIBRARY_PATH") {
-        env::split_paths(&path)
-            .map(|x| x.to_string_lossy().into())
-            .collect_into(&mut directories);
+        directories.extend(
+            env::split_paths(&path).map(|x| x.to_string_lossy().into()),
+        );
     }
 
     if target_os!("linux") || target_os!("freebsd") {
-        DIRECTORIES_LINUX
-            .into_iter()
-            .map(|x| x.to_string())
-            .collect_into(&mut directories);
+        directories.extend(DIRECTORIES_LINUX.iter().map(|x| x.to_string()));
     } else if target_os!("macos") {
-        DIRECTORIES_MACOS
-            .into_iter()
-            .map(|x| x.to_string())
-            .collect_into(&mut directories);
+        directories.extend(DIRECTORIES_MACOS.iter().map(|x| x.to_string()));
     } else if target_os!("windows") {
         let msvc = target_env!("msvc");
-        DIRECTORIES_WINDOWS
-            .iter()
-            .filter(|d| d.1 || !msvc)
-            .map(|d| d.0.into())
-            .collect_into(&mut directories);
+        directories.extend(
+            DIRECTORIES_WINDOWS
+                .iter()
+                .filter(|d| d.1 || !msvc)
+                .map(|d| d.0.into()),
+        );
     }
 
     if let Ok(home_dir) = env::var("HOME") {
         let local_dir: PathBuf = [home_dir, ".local".into()].iter().collect();
-        DIRECTORIES_LOCAL
-            .iter()
-            .map(|x| local_dir.join(*x).to_string_lossy().into())
-            .collect_into(&mut directories);
+        directories.extend(
+            DIRECTORIES_LOCAL
+                .iter()
+                .map(|x| local_dir.join(*x).to_string_lossy().into()),
+        );
     }
 
     // We use temporary directories when testing the build script, so we'll

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(non_null_convenience)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -307,7 +307,7 @@ impl<T> TryFrom<*mut RzVector> for Vector<T> {
 
 impl<T> AsMut<[T]> for Vector<T> {
     fn as_mut(&mut self) -> &mut [T] {
-        self
+        unsafe { slice::from_raw_parts_mut(self.as_mut_ptr(), self.len()) }
     }
 }
 
@@ -315,13 +315,13 @@ impl<T> Deref for Vector<T> {
     type Target = [T];
 
     fn deref(&self) -> &Self::Target {
-        unsafe { slice::from_raw_parts_mut(self.as_mut_ptr(), self.len()) }
+        unsafe { slice::from_raw_parts(self.as_mut_ptr() as *const T, self.len()) }
     }
 }
 
 impl<T> DerefMut for Vector<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.as_mut()
+        unsafe { slice::from_raw_parts_mut(self.as_mut_ptr(), self.len()) }
     }
 }
 


### PR DESCRIPTION
## Summary
- stop using `feature(iter_collect_into)` in the build script
- avoid nightly `collect_into` by using `extend`
- drop `non_null_convenience` feature gate
- fix unsound slice handling in `Vector` deref implementations

## Testing
- `cargo check` *(fails: couldn't find rizin libraries)*

------
https://chatgpt.com/codex/tasks/task_e_6844df29ea4c8323b1fbebab1c4eafcb